### PR TITLE
IPV6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Le script vise à automatiser la mise à jour des enregistrements DNS A pour un sous-domaine spécifié chez les fournisseurs de services en ligne tels que Online.net. Cela est particulièrement utile dans les scénarios où l'adresse IP de l'hôte change régulièrement.
 
+⚠️ Veuillez noter que ce script est actuellement limité à la gestion des adresses IPv4 uniquement. Les adresses IPv6 ne sont pas prises en charge pour le moment. Assurez-vous que vos configurations et attentes sont alignées avec cette limitation. ⚠️
+
 ## Fonctionnalités
 
 1. **Compatibilité Multi-Fournisseurs:** Le script est conçu pour fonctionner avec les API de plusieurs fournisseurs de services, en se concentrant sur Online.net.
@@ -54,6 +56,7 @@ services:
       - DOMAINS=exemple.fr,exemple-2.fr
       - SUBDOMAINS=@,*
       - TYPES=A
+      - CHECK_PUBLIC_IPv4=true #optional
     restart: unless-stopped
 ````
 Les  logs sont stocké dans le docker `/usr/src/app/log`
@@ -71,6 +74,7 @@ services:
       - DOMAINS=exemple.fr,exemple-2.fr
       - SUBDOMAINS=@,*
       - TYPES=A
+      - CHECK_PUBLIC_IPv4=true #optional
     dns:
       -8.8.8.8
     restart: unless-stopped
@@ -95,6 +99,7 @@ services:
       - DOMAINS=exemple.fr,exemple-2.fr
       - SUBDOMAINS=@,*
       - TYPES=A
+      - CHECK_PUBLIC_IPv4=true #optional
     dns:
       -8.8.8.8
     command: ["php", "/usr/src/app/ddns_update.php"]
@@ -105,12 +110,13 @@ services:
 php ddns_update.php
 ```
 
-| Variable        | Description                                                                                                    |
-| --------------- | -------------------------------------------------------------------------------------------------------------- |
-| `ONLINE_TOKEN`  | Remplacez "MonTokenOniline.Net" par votre clé API Online.net. Obtenez cette clé depuis [la console Online.net](https://console.online.net/fr/api/access). |
-| `DOMAINS`       | Indiquez la liste de vos domaines séparés par des virgules. Par exemple, `exemple.fr,exemple-2.fr`.             |
-| `SUBDOMAINS`    | Spécifiez les sous-domaines séparés par des virgules que vous souhaitez mettre à jour. Utilisez `@` pour le domaine principal et `*` pour tous les sous-domaines (par exemple, `@,*`). |
-| `TYPES`         | Indiquez le type d'enregistrement DNS à mettre à jour. Par exemple, `A` pour un enregistrement de type Adresse IPv4. |
-| `LOG_PATH`      | (Optionnel) Le chemin du répertoire pour les logs. Si vous souhaitez les stocker dans un volume, spécifiez le chemin ici (par exemple, `/log`). |
+| Variable              | Type     | Description                                                                                                    |
+| --------------------- | :------- | -------------------------------------------------------------------------------------------------------------- |
+| `ONLINE_TOKEN`        | `string` | Remplacez "MonTokenOniline.Net" par votre clé API Online.net. Obtenez cette clé depuis [la console Online.net](https://console.online.net/fr/api/access). |
+| `DOMAINS`             | `string` | Indiquez la liste de vos domaines séparés par des virgules. Par exemple, `exemple.fr,exemple-2.fr`.             |
+| `SUBDOMAINS`          | `string` | Spécifiez les sous-domaines séparés par des virgules que vous souhaitez mettre à jour. Utilisez `@` pour le domaine principal et `*` pour tous les sous-domaines (par exemple, `@,*`). |
+| `TYPES`               | `A` or  `AAAA` or `A,AAAA` | Indiquez le type d'enregistrement DNS à mettre à jour. Par exemple, `A`  (par défaut) pour un enregistrement de type Adresse IPv4. |
+| `CHECK_PUBLIC_IPv4`   | `boolean` | (Optionnel) Si défini à true (par défaut), vérifie que l'adresse IP récupérée est une adresse publique. Sinon, cette vérification est ignorée. |
+| `LOG_PATH`            | `string` | (Optionnel) Le chemin du répertoire pour les logs. Si vous souhaitez les stocker dans un volume, spécifiez le chemin ici (par exemple, `/log`). |
 
 Ce README a été créé avec le soutien d'une intelligence artificielle pour fournir des informations claires et utiles.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Le script vise à automatiser la mise à jour des enregistrements DNS A pour un sous-domaine spécifié chez les fournisseurs de services en ligne tels que Online.net. Cela est particulièrement utile dans les scénarios où l'adresse IP de l'hôte change régulièrement.
 
-⚠️ Veuillez noter que ce script est actuellement limité à la gestion des adresses IPv4 uniquement. Les adresses IPv6 ne sont pas prises en charge pour le moment. Assurez-vous que vos configurations et attentes sont alignées avec cette limitation. ⚠️
+⚠️ Les adresses IPv6 ne sont pas encore entièrement prises en charge. Assurez-vous que vos configurations et attentes sont alignées avec cette limitation. ⚠️
 
 ## Fonctionnalités
 
@@ -75,8 +75,10 @@ services:
       - SUBDOMAINS=@,*
       - TYPES=A
       - CHECK_PUBLIC_IPv4=true #optional
+      - CHECK_PUBLIC_IP6=true #optional
     dns:
       -8.8.8.8
+      -2001:4860:4860::8888
     restart: unless-stopped
 ````
 
@@ -100,8 +102,10 @@ services:
       - SUBDOMAINS=@,*
       - TYPES=A
       - CHECK_PUBLIC_IPv4=true #optional
+      - CHECK_PUBLIC_IP6=true #optional
     dns:
       -8.8.8.8
+      -2001:4860:4860::8888
     command: ["php", "/usr/src/app/ddns_update.php"]
     restart: unless-stopped
 ````
@@ -114,9 +118,10 @@ php ddns_update.php
 | --------------------- | :------- | -------------------------------------------------------------------------------------------------------------- |
 | `ONLINE_TOKEN`        | `string` | Remplacez "MonTokenOniline.Net" par votre clé API Online.net. Obtenez cette clé depuis [la console Online.net](https://console.online.net/fr/api/access). |
 | `DOMAINS`             | `string` | Indiquez la liste de vos domaines séparés par des virgules. Par exemple, `exemple.fr,exemple-2.fr`.             |
-| `SUBDOMAINS`          | `string` | Spécifiez les sous-domaines séparés par des virgules que vous souhaitez mettre à jour. Utilisez `@` pour le domaine principal et `*` pour tous les sous-domaines (par exemple, `@,*`). |
-| `TYPES`               | `A` or  `AAAA` or `A,AAAA` | Indiquez le type d'enregistrement DNS à mettre à jour. Par exemple, `A`  (par défaut) pour un enregistrement de type Adresse IPv4. |
-| `CHECK_PUBLIC_IPv4`   | `boolean` | (Optionnel) Si défini à true (par défaut), vérifie que l'adresse IP récupérée est une adresse publique. Sinon, cette vérification est ignorée. |
-| `LOG_PATH`            | `string` | (Optionnel) Le chemin du répertoire pour les logs. Si vous souhaitez les stocker dans un volume, spécifiez le chemin ici (par exemple, `/log`). |
+| `SUBDOMAINS`          | `string` | Spécifiez les sous-domaines séparés par des virgules que vous souhaitez mettre à jour. Utilisez `@` pour le domaine principal et `*` pour tous les sous-domaines. *Par default: `*,@`* |
+| `TYPES`               | `A` or  `AAAA` or `A,AAAA` | Indiquez le type d'enregistrement DNS à mettre à jour. Par exemple, `A`  (par défaut) pour un enregistrement de type Adresse IPv4. *Par default: `A,AAAA`* |
+| `CHECK_PUBLIC_IPv4`   | `boolean` | **Optionnel** Si défini à `true`, vérifie que l'adresse IP récupérée est une adresse publique. Sinon, cette vérification est ignorée. *Par default: `true`* |
+| `CHECK_PUBLIC_IPv6`   | `boolean` | **Optionnel** Si défini à `true`, vérifie que l'adresse IP récupérée est une adresse publique. Sinon, cette vérification est ignorée. *Par default: `true`* |
+| `LOG_PATH`            | `string` | **Optionnel** Le chemin du répertoire pour les logs. Si vous souhaitez les stocker dans un volume, spécifiez le chemin ici (par exemple, `/log`). |
 
 Ce README a été créé avec le soutien d'une intelligence artificielle pour fournir des informations claires et utiles.

--- a/ddns_update.php
+++ b/ddns_update.php
@@ -129,6 +129,35 @@ while (true) {
                 $address = $ipData['ip'];
 
                 writeToLog("🌐 Adresse IP actuelle : $address\n");
+                writeToLog("🔍 Vérification de l'IP pour $sub.$domain...\n");
+
+                if ($sub === "@") {
+                    $ipyet = gethostbyname($domain); // Récupération de l'IP en service sur l'enregistrement DNS.
+                } elseif ($sub === "*") {
+                    $ipyet = gethostbyname("testdnsall." . $domain); // Récupération de l'IP en service sur l'enregistrement DNS.
+                } else {
+                    $ipyet = gethostbyname("$sub.$domain"); // Récupération de l'IP en service sur l'enregistrement DNS.
+                }
+    
+                writeToLog("📊 IP actuelle : $address\n");
+                writeToLog("📌 IP enregistrée : $ipyet\n");
+    
+                if ($ipyet !== $address) { // Comparaison de la nouvelle IP et de celle en service.
+                    $ch = curl_init();
+    
+                    $URL =  "domain/" . $domain . "/version/active";
+                    $POSTFIELDS = "[{\"name\": \"$sub\",\"type\": \"$types\",\"changeType\": \"REPLACE\",\"records\": [{\"name\": \"$sub\",\"type\": \"$types\",\"priority\": 0,\"ttl\": 3600,\"data\": \"$address\"}]}]";
+                    $result = OnlineApi($URL, $POSTFIELDS, "PATCH");
+    
+                    if ($result === null) {
+                        writeToLog("⏰ Erreur ENVOI pour $sub.$domain" . "\n");
+                    } else {
+                        writeToLog("✅ IP mise à jour avec succès pour $sub.$domain\n\n");
+                    }
+    
+                } else {
+                    writeToLog("🔄 IP inchangée pour $sub.$domain !\n\n");
+                }
             } else {
                 $error = error_get_last();
                 writeToLog("❌ Impossible de récupérer l'adresse IP. Erreur : " . $error['message'] . "\n");
@@ -136,36 +165,6 @@ while (true) {
                 if (checkInternetConnection()) {
                     writeToLog("❌ Erreur : La connexion Internet fonctionne, mais une erreur est survenue avec l'API ipify.\n");
                 }
-            }
-
-            writeToLog("🔍 Vérification de l'IP pour $sub.$domain...\n");
-
-            if ($sub === "@") {
-                $ipyet = gethostbyname($domain); // Récupération de l'IP en service sur l'enregistrement DNS.
-            } elseif ($sub === "*") {
-                $ipyet = gethostbyname("testdnsall." . $domain); // Récupération de l'IP en service sur l'enregistrement DNS.
-            } else {
-                $ipyet = gethostbyname("$sub.$domain"); // Récupération de l'IP en service sur l'enregistrement DNS.
-            }
-
-            writeToLog("📊 IP actuelle : $address\n");
-            writeToLog("📌 IP enregistrée : $ipyet\n");
-
-            if ($ipyet !== $address) { // Comparaison de la nouvelle IP et de celle en service.
-                $ch = curl_init();
-
-                $URL =  "domain/" . $domain . "/version/active";
-                $POSTFIELDS = "[{\"name\": \"$sub\",\"type\": \"$types\",\"changeType\": \"REPLACE\",\"records\": [{\"name\": \"$sub\",\"type\": \"$types\",\"priority\": 0,\"ttl\": 3600,\"data\": \"$address\"}]}]";
-                $result = OnlineApi($URL, $POSTFIELDS, "PATCH");
-
-                if ($result === null) {
-                    writeToLog("⏰ Erreur ENVOI pour $sub.$domain" . "\n");
-                } else {
-                    writeToLog("✅ IP mise à jour avec succès pour $sub.$domain\n\n");
-                }
-
-            } else {
-                writeToLog("🔄 IP inchangée pour $sub.$domain !\n\n");
             }
         }
     }


### PR DESCRIPTION
- Moved the block responsible for retrieving and comparing IP addresses for each subdomain and ipApiResponse is true.
 -Ajout d'une fonction pour vérifier si l'adresse IP récupérée est publique.
-Mis à jour le script pour journaliser un message d'erreur si l'adresse IP n'est pas publique.
-Ajout de la limitation IPv4
-Adaptation de la boucle principale pour gérer les mises à jour d'IPv4 et d'IPv6 en fonction des types spécifiés.
- Mise à jour de la gestion des erreurs et des logs pour prendre en compte les éventuels problèmes avec la récupération d'IPv6.
- Refonte des fonctions existantes pour assurer la compatibilité avec la comparaison des adresses IPv4 et IPv6.